### PR TITLE
Add simple logging infrastructure based on `@vscode-logging/logger`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,9 @@
     "packages": {
         "": {
             "version": "0.0.1",
+            "dependencies": {
+                "@vscode-logging/logger": "^1.2.3"
+            },
             "devDependencies": {
                 "@types/mocha": "^7.0.2",
                 "@types/node": "^13.11.0",
@@ -47,6 +50,16 @@
                 "@babel/helper-validator-identifier": "^7.14.0",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            }
+        },
+        "node_modules/@dabh/diagnostics": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+            "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+            "dependencies": {
+                "colorspace": "1.1.x",
+                "enabled": "2.0.x",
+                "kuler": "^2.0.0"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -114,7 +127,8 @@
         "node_modules/@types/vscode": {
             "version": "1.56.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ=="
+            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+            "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "4.22.1",
@@ -273,6 +287,27 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@vscode-logging/logger": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@vscode-logging/logger/-/logger-1.2.3.tgz",
+            "integrity": "sha512-kQgRjbZmBBUktklaEat8YtTBuddCNRJezjJTk0Y+4VIs49KWjYkfF02GoyiCYASvCSMSqw9bBTQN3ijCO2aq+A==",
+            "dependencies": {
+                "@vscode-logging/types": "^0.1.4",
+                "fast-safe-stringify": "2.0.7",
+                "fs-extra": "9.1.0",
+                "lodash": "^4.17.21",
+                "stacktrace-js": "2.0.2",
+                "streamroller": "2.2.3",
+                "triple-beam": "1.3.0",
+                "winston": "3.3.3",
+                "winston-transport": "4.3.0"
+            }
+        },
+        "node_modules/@vscode-logging/types": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@vscode-logging/types/-/types-0.1.4.tgz",
+            "integrity": "sha512-uxuHQfpX9RbkgSj5unJFmciXRczyFSaAI2aA829MYYkE8jxlhZLRLoiJLymTNiojNVdV7fFE3CILF5Q6M+EBsA=="
+        },
         "node_modules/acorn": {
             "version": "7.4.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -417,6 +452,19 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/async": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/balanced-match": {
@@ -647,11 +695,19 @@
                 "node": ">=6"
             }
         },
+        "node_modules/color": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+            "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+            "dependencies": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+            }
+        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "dependencies": {
                 "color-name": "1.1.3"
             }
@@ -659,8 +715,33 @@
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "node_modules/color-string": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
+        "node_modules/colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/colorspace": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+            "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+            "dependencies": {
+                "color": "3.0.x",
+                "text-hex": "1.0.x"
+            }
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -671,8 +752,7 @@
         "node_modules/core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "node_modules/cross-spawn": {
             "version": "6.0.5",
@@ -699,11 +779,18 @@
                 "semver": "bin/semver"
             }
         },
+        "node_modules/date-format": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+            "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -790,6 +877,19 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "node_modules/enabled": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "node_modules/error-stack-parser": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+            "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+            "dependencies": {
+                "stackframe": "^1.1.1"
+            }
         },
         "node_modules/es-abstract": {
             "version": "1.18.0",
@@ -1149,6 +1249,11 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "node_modules/fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+        },
         "node_modules/fastq": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
@@ -1157,6 +1262,11 @@
             "dependencies": {
                 "reusify": "^1.0.4"
             }
+        },
+        "node_modules/fecha": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+            "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -1241,26 +1351,30 @@
             "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
             "dev": true
         },
+        "node_modules/fn.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+        },
+        "node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
-        },
-        "node_modules/fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-            "deprecated": "\"Please update to latest v2.3 or v2.2\"",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/fstream": {
             "version": "1.0.12",
@@ -1388,8 +1502,7 @@
         "node_modules/graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-            "dev": true
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "node_modules/growl": {
             "version": "1.10.5",
@@ -1537,8 +1650,7 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/inquirer": {
             "version": "7.3.3",
@@ -1654,6 +1766,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/is-arrayish": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         },
         "node_modules/is-bigint": {
             "version": "1.0.2",
@@ -1817,6 +1934,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-string": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
@@ -1847,8 +1972,7 @@
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -1887,6 +2011,22 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "node_modules/jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/kuler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+        },
         "node_modules/levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -1922,8 +2062,7 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/log-symbols": {
             "version": "3.0.0",
@@ -1935,6 +2074,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/logform": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+            "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+            "dependencies": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^4.2.0",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
             }
         },
         "node_modules/lru-cache": {
@@ -2106,8 +2257,7 @@
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
@@ -2212,6 +2362,14 @@
             "dev": true,
             "dependencies": {
                 "wrappy": "1"
+            }
+        },
+        "node_modules/one-time": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+            "dependencies": {
+                "fn.name": "1.x.x"
             }
         },
         "node_modules/onetime": {
@@ -2363,8 +2521,7 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "node_modules/progress": {
             "version": "2.0.3",
@@ -2408,7 +2565,6 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2549,8 +2705,7 @@
         "node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -2612,6 +2767,14 @@
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
             "dev": true
         },
+        "node_modules/simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "dependencies": {
+                "is-arrayish": "^0.3.1"
+            }
+        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -2644,17 +2807,106 @@
                 "node": ">=4"
             }
         },
+        "node_modules/source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "node_modules/stack-generator": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+            "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+            "dependencies": {
+                "stackframe": "^1.1.1"
+            }
+        },
+        "node_modules/stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/stackframe": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+            "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+        },
+        "node_modules/stacktrace-gps": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+            "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+            "dependencies": {
+                "source-map": "0.5.6",
+                "stackframe": "^1.1.1"
+            }
+        },
+        "node_modules/stacktrace-js": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+            "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+            "dependencies": {
+                "error-stack-parser": "^2.0.6",
+                "stack-generator": "^2.0.5",
+                "stacktrace-gps": "^3.0.4"
+            }
+        },
+        "node_modules/streamroller": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
+            "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+            "dependencies": {
+                "date-format": "^2.1.0",
+                "debug": "^4.1.1",
+                "fs-extra": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=8.0"
+            }
+        },
+        "node_modules/streamroller/node_modules/fs-extra": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dependencies": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/streamroller/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/streamroller/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
         "node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -2800,6 +3052,11 @@
                 "node": ">=6"
             }
         },
+        "node_modules/text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+        },
         "node_modules/text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2841,6 +3098,11 @@
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
             "dev": true
+        },
+        "node_modules/triple-beam": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
         },
         "node_modules/tslib": {
             "version": "1.14.1",
@@ -2912,6 +3174,14 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
         "node_modules/unzipper": {
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
@@ -2942,8 +3212,7 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "node_modules/v8-compile-cache": {
             "version": "2.3.0",
@@ -3077,6 +3346,76 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/winston": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+            "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+            "dependencies": {
+                "@dabh/diagnostics": "^2.0.2",
+                "async": "^3.1.0",
+                "is-stream": "^2.0.0",
+                "logform": "^2.2.0",
+                "one-time": "^1.0.0",
+                "readable-stream": "^3.4.0",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.4.0"
+            },
+            "engines": {
+                "node": ">= 6.4.0"
+            }
+        },
+        "node_modules/winston-transport": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+            "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+            "dependencies": {
+                "readable-stream": "^2.3.6",
+                "triple-beam": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 6.4.0"
+            }
+        },
+        "node_modules/winston/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/winston/node_modules/winston-transport": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+            "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+            "dependencies": {
+                "readable-stream": "^2.3.7",
+                "triple-beam": "^1.2.0"
+            },
+            "engines": {
+                "node": ">= 6.4.0"
+            }
+        },
+        "node_modules/winston/node_modules/winston-transport/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "node_modules/word-wrap": {
@@ -3260,6 +3599,16 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@dabh/diagnostics": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+            "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+            "requires": {
+                "colorspace": "1.1.x",
+                "enabled": "2.0.x",
+                "kuler": "^2.0.0"
+            }
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz",
@@ -3313,7 +3662,8 @@
         "@types/vscode": {
             "version": "1.56.0",
             "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
-            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ=="
+            "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
+            "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
             "version": "4.22.1",
@@ -3397,6 +3747,27 @@
                 "@typescript-eslint/types": "4.22.1",
                 "eslint-visitor-keys": "^2.0.0"
             }
+        },
+        "@vscode-logging/logger": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@vscode-logging/logger/-/logger-1.2.3.tgz",
+            "integrity": "sha512-kQgRjbZmBBUktklaEat8YtTBuddCNRJezjJTk0Y+4VIs49KWjYkfF02GoyiCYASvCSMSqw9bBTQN3ijCO2aq+A==",
+            "requires": {
+                "@vscode-logging/types": "^0.1.4",
+                "fast-safe-stringify": "2.0.7",
+                "fs-extra": "9.1.0",
+                "lodash": "^4.17.21",
+                "stacktrace-js": "2.0.2",
+                "streamroller": "2.2.3",
+                "triple-beam": "1.3.0",
+                "winston": "3.3.3",
+                "winston-transport": "4.3.0"
+            }
+        },
+        "@vscode-logging/types": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/@vscode-logging/types/-/types-0.1.4.tgz",
+            "integrity": "sha512-uxuHQfpX9RbkgSj5unJFmciXRczyFSaAI2aA829MYYkE8jxlhZLRLoiJLymTNiojNVdV7fFE3CILF5Q6M+EBsA=="
         },
         "acorn": {
             "version": "7.4.1",
@@ -3500,6 +3871,16 @@
             "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
             "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
+        },
+        "async": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
+            "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+        },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -3687,11 +4068,19 @@
                 }
             }
         },
+        "color": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
+            "integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
+            "requires": {
+                "color-convert": "^1.9.1",
+                "color-string": "^1.5.2"
+            }
+        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -3699,8 +4088,30 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "color-string": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
+            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
+        "colors": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+        },
+        "colorspace": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.2.tgz",
+            "integrity": "sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==",
+            "requires": {
+                "color": "3.0.x",
+                "text-hex": "1.0.x"
+            }
         },
         "concat-map": {
             "version": "0.0.1",
@@ -3711,8 +4122,7 @@
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-            "dev": true
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
             "version": "6.0.5",
@@ -3735,11 +4145,15 @@
                 }
             }
         },
+        "date-format": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/date-format/-/date-format-2.1.0.tgz",
+            "integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA=="
+        },
         "debug": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -3803,6 +4217,19 @@
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
+        },
+        "enabled": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
+        "error-stack-parser": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+            "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+            "requires": {
+                "stackframe": "^1.1.1"
+            }
         },
         "es-abstract": {
             "version": "1.18.0",
@@ -4080,6 +4507,11 @@
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
         },
+        "fast-safe-stringify": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+        },
         "fastq": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.11.0.tgz",
@@ -4088,6 +4520,11 @@
             "requires": {
                 "reusify": "^1.0.4"
             }
+        },
+        "fecha": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+            "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
         "figures": {
             "version": "3.2.0",
@@ -4151,18 +4588,27 @@
             "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
             "dev": true
         },
+        "fn.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+        },
+        "fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "requires": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
             "dev": true
-        },
-        "fsevents": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-            "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-            "dev": true,
-            "optional": true
         },
         "fstream": {
             "version": "1.0.12",
@@ -4262,8 +4708,7 @@
         "graceful-fs": {
             "version": "4.2.6",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
-            "dev": true
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
         },
         "growl": {
             "version": "1.10.5",
@@ -4369,8 +4814,7 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "inquirer": {
             "version": "7.3.3",
@@ -4458,6 +4902,11 @@
                     }
                 }
             }
+        },
+        "is-arrayish": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         },
         "is-bigint": {
             "version": "1.0.2",
@@ -4550,6 +4999,11 @@
                 "has-symbols": "^1.0.2"
             }
         },
+        "is-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
         "is-string": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
@@ -4568,8 +5022,7 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "dev": true
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -4605,6 +5058,20 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "jsonfile": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            }
+        },
+        "kuler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+        },
         "levn": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4634,8 +5101,7 @@
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "dev": true
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "log-symbols": {
             "version": "3.0.0",
@@ -4644,6 +5110,18 @@
             "dev": true,
             "requires": {
                 "chalk": "^2.4.2"
+            }
+        },
+        "logform": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
+            "integrity": "sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==",
+            "requires": {
+                "colors": "^1.2.1",
+                "fast-safe-stringify": "^2.0.4",
+                "fecha": "^4.2.0",
+                "ms": "^2.1.1",
+                "triple-beam": "^1.3.0"
             }
         },
         "lru-cache": {
@@ -4778,8 +5256,7 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "mute-stream": {
             "version": "0.0.8",
@@ -4865,6 +5342,14 @@
             "dev": true,
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "one-time": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+            "requires": {
+                "fn.name": "1.x.x"
             }
         },
         "onetime": {
@@ -4968,8 +5453,7 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-            "dev": true
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
         },
         "progress": {
             "version": "2.0.3",
@@ -4993,7 +5477,6 @@
             "version": "2.3.7",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -5089,8 +5572,7 @@
         "safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-            "dev": true
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -5140,6 +5622,14 @@
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
             "dev": true
         },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            }
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -5165,17 +5655,93 @@
                 }
             }
         },
+        "source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
+        "stack-generator": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+            "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+            "requires": {
+                "stackframe": "^1.1.1"
+            }
+        },
+        "stack-trace": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+        },
+        "stackframe": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+            "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+        },
+        "stacktrace-gps": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+            "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+            "requires": {
+                "source-map": "0.5.6",
+                "stackframe": "^1.1.1"
+            }
+        },
+        "stacktrace-js": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+            "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+            "requires": {
+                "error-stack-parser": "^2.0.6",
+                "stack-generator": "^2.0.5",
+                "stacktrace-gps": "^3.0.4"
+            }
+        },
+        "streamroller": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
+            "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+            "requires": {
+                "date-format": "^2.1.0",
+                "debug": "^4.1.1",
+                "fs-extra": "^8.1.0"
+            },
+            "dependencies": {
+                "fs-extra": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
+                    }
+                },
+                "universalify": {
+                    "version": "0.1.2",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+                    "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+                }
+            }
+        },
         "string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "~5.1.0"
             }
@@ -5289,6 +5855,11 @@
                 }
             }
         },
+        "text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+        },
         "text-table": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5324,6 +5895,11 @@
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
             "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
             "dev": true
+        },
+        "triple-beam": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
         },
         "tslib": {
             "version": "1.14.1",
@@ -5373,6 +5949,11 @@
                 "which-boxed-primitive": "^1.0.2"
             }
         },
+        "universalify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
         "unzipper": {
             "version": "0.10.11",
             "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
@@ -5403,8 +5984,7 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-            "dev": true
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "v8-compile-cache": {
             "version": "2.3.0",
@@ -5515,6 +6095,68 @@
                         "ansi-regex": "^3.0.0"
                     }
                 }
+            }
+        },
+        "winston": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+            "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+            "requires": {
+                "@dabh/diagnostics": "^2.0.2",
+                "async": "^3.1.0",
+                "is-stream": "^2.0.0",
+                "logform": "^2.2.0",
+                "one-time": "^1.0.0",
+                "readable-stream": "^3.4.0",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.4.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "winston-transport": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.0.tgz",
+                    "integrity": "sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==",
+                    "requires": {
+                        "readable-stream": "^2.3.7",
+                        "triple-beam": "^1.2.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "2.3.7",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                            "requires": {
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~2.0.0",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.1.1",
+                                "util-deprecate": "~1.0.1"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "winston-transport": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.3.0.tgz",
+            "integrity": "sha512-B2wPuwUi3vhzn/51Uukcao4dIduEiPOcOt9HJ3QeaXgkJ5Z7UwpBzxS4ZGNHtrxrUvTwemsQiSys0ihOf8Mp1A==",
+            "requires": {
+                "readable-stream": "^2.3.6",
+                "triple-beam": "^1.2.0"
             }
         },
         "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
         "pretest": "npm run compile && npm run lint",
         "test": "node ./out/test/runTest.js"
     },
+    "dependencies": {
+        "@vscode-logging/logger": "^1.2.3"
+    },
     "devDependencies": {
         "@types/mocha": "^7.0.2",
         "@types/node": "^13.11.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,17 +1,26 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { getExtensionLogger } from '@vscode-logging/logger';
 
-// Logging
+// Logging output channel
 const nisabaOutputChannel = vscode.window.createOutputChannel("Nisaba");
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
 
-    // Use the console to output diagnostic information (console.log) and errors (console.error)
-    // This line of code will only be executed once when your extension is activated
-    console.log('Congratulations, your extension "ucl-rsdg" is now active!');
+    // Set up logging with `@vscode-logging/logger`
+    const extLogger = getExtensionLogger({
+        extName: "Nisaba",
+        level: "info", // See LogLevel type in @vscode-logging/types for possible logLevels
+        logPath: context.logPath, // The logPath is only available from the `vscode.ExtensionContext`
+        logOutputChannel: nisabaOutputChannel, // OutputChannel for the logger
+        sourceLocationTracking: false,
+        logConsole: true // define if messages should be logged to the console
+    });
+
+    extLogger.info('Congratulations, your extension "ucl-rsdg" is now active!');
 
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with registerCommand
@@ -22,8 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
         // Display a message box to the user
         const str = 'Hello VS Code from ucl-rsdg!';
         vscode.window.showWarningMessage(str);
-        nisabaOutputChannel.show();
-        nisabaOutputChannel.append(str + '\n');
+        extLogger.info(str);
     });
 
     context.subscriptions.push(disposable);


### PR DESCRIPTION
Address #26.

Some comments:

* contrary to what I said in #26, using `console.log` doesn't necessarily seem
  like a good idea
* I looked at the extension [listed by Anastasis](https://github.com/oracc/nisaba/issues/26#issuecomment-853864882),
  they all look good, but are for more general Javascript use
* The nice thing about `@vscode-logging/logger` is that it's built on top of a
  popular extension, Winston (one of those mentioned by Anastasis), but also
  knows a bit about VS Code internal logging mechanism
* related to the point above, this extension allows us to log messages to both
  the console output and a file at the same time
* at the moment I am writing log files to `context.logPath` directory, which for
  me is `~/.config/Code/logs/<TIMESTAMP>/exthost1/ucl-rsdg.nisaba`, which
  doesn't look incredibly convenient.  We can change this path, and the
  directory will be created automatically as needed.  I'd suggest to have some
  sort of timestamp, or at least the date, to keep logs smaller
* logs to both console output and file are written as JSON, which however isn't
  particularly human-friendly, but hey, this is javascript
* we can have multiple loggers, all writing to the same file/console output, but
  we can also have them to write to different files (might become a bit
  confusing perhaps).  Also, each logger can have children loggers, which have
  different labels (the format is `Parent.Child`)