### PR TITLE
Show output channel before sending logging messages

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,6 +17,7 @@ class OutputChannelTransport extends TransportStream {
             this.emit('logged', info);
         });
 
+        this.outputChannel.show();
         this.outputChannel.appendLine(`[${info.label}] ${info.level}: ${info.message}`);
 
         if (callback) {


### PR DESCRIPTION
During today pair programming I realised that we need to call this function to
actually show the output channel, if not visible already.