### PR TITLE
Include zip in validation request

### DIFF
--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -29,7 +29,7 @@ export function validate(filename: string, project: string, text: string): Serve
     const encodedText = zip.toBuffer().toString();
     // TODO replace this with appropriate commands and reponse ID params
     const fullMessage = createMultipart("atf", filename, project, encodedText,
-                                        "responseID");
+                                        null);
     let body = fullMessage.toString({noHeaders: true});
     const boundary = fullMessage.contentType().params.boundary;
 


### PR DESCRIPTION
Fixes #50. This should no longer produce a 400 error when submitting the validation request (the code will fail later on our side when waiting for the final response but that is due to a known problem).

It would be good to have a regression test for this (i.e. that the message we create for the initial request contains the attachment). Any ideas?