### PR TITLE
Display validation results

### DIFF
--- a/src/client/server_result.ts
+++ b/src/client/server_result.ts
@@ -69,7 +69,7 @@ export class ServerResult {
     get_user_log(){
         /* This method will build the log the user will see in the VS code
            console */
-        if (Object.keys(this.validation_errors).length == 0){
+        if (!this.contains_errors()){
             return "ATF validation returned no errors.";
         }
         else {
@@ -80,5 +80,9 @@ export class ServerResult {
             user_log += os.EOL + this.summary_line;
             return user_log;
         }
+    }
+
+    contains_errors(): boolean {
+        return Object.keys(this.validation_errors).length != 0
     }
 }

--- a/src/client/server_result.ts
+++ b/src/client/server_result.ts
@@ -76,7 +76,7 @@ export class ServerResult {
         }
         else {
             let user_log = Object.entries(this.validation_errors)
-                .map(([line_num, error_msg]) =>`${filepath}:${line_num}: ${error_msg}.`)
+                .map(([line_num, error_msg]) =>`${filepath}:${line_num}:${os.EOL}${error_msg}.`)
                 .join(os.EOL)
             // Add summary line at the end
             user_log += os.EOL + this.summary_line;

--- a/src/client/server_result.ts
+++ b/src/client/server_result.ts
@@ -2,7 +2,6 @@ import * as os from 'os';
 
 export class ServerResult {
 
-    user_log: string;
     validation_errors: { [line_num: number]: string };
     summary_line: string; // This is the last line that shows in the log
                           // by the Oracc server
@@ -16,7 +15,6 @@ export class ServerResult {
     constructor(oracc_log: string, request_log: string = ""){
         this.summary_line = "";
         this.validation_errors = this.get_validation_errors(oracc_log);
-        this.user_log = this.get_user_log();
         this.request_log = request_log;
         this.atf_content = ""; //placeholder for lemmatisation
 
@@ -66,15 +64,19 @@ export class ServerResult {
         return validation_errors;
     }
 
-    get_user_log(){
-        /* This method will build the log the user will see in the VS code
-           console */
+    /**
+     * Build the log the user will see in the VS Code console.
+     * @param filepath The path of the ATF file, to be shown with each message
+     * @returns Each message with the filename prepended (for easy navigation)
+     * and a summary line
+     */
+    get_user_log(filepath: string){
         if (!this.contains_errors()){
             return "ATF validation returned no errors.";
         }
         else {
             let user_log = Object.entries(this.validation_errors)
-                .map(([line_num, error_msg]) =>`Line ${line_num}: ${error_msg}.`)
+                .map(([line_num, error_msg]) =>`${filepath}:${line_num}: ${error_msg}.`)
                 .join(os.EOL)
             // Add summary line at the end
             user_log += os.EOL + this.summary_line;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,10 @@
-import { handleResult, validate } from './server/messages';
+import { validate } from './server/messages';
 
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import * as nisabaLogger from './logger';
+import { handleResult, initView } from './view';
 import { PreviewPanel } from './preview';
 
 // Logging output channel
@@ -14,6 +15,7 @@ const nisabaOutputChannel = vscode.window.createOutputChannel("Nisaba");
 export function activate(context: vscode.ExtensionContext) {
 
     nisabaLogger.initLogging(nisabaOutputChannel);
+    initView();
 
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with registerCommand

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import { validate } from './server/messages';
+import { handleResult, validate } from './server/messages';
 
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
@@ -35,7 +35,8 @@ export function activate(context: vscode.ExtensionContext) {
         const fileProject = "cams/gkab";
         const fileContent = vscode.window.activeTextEditor.document.getText();
         // The validate function is currently not mapped to the appropriate logging functions
-        validate(filePath,fileProject,fileContent);
+        const result = validate(filePath,fileProject,fileContent);
+        handleResult(result);
         });
 
     context.subscriptions.push(disposable2);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,13 +32,13 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(disposable1);
 
     const disposable2 = vscode.commands.registerCommand('ucl-rsdg.validateAtf', () => {
-        // The code you place here will be executed every time your command is 
-        const filePath = vscode.window.activeTextEditor.document.uri.fsPath;
+        const editor = vscode.window.activeTextEditor;
+        const filePath = editor.document.uri.fsPath;
         const fileProject = "cams/gkab";
-        const fileContent = vscode.window.activeTextEditor.document.getText();
+        const fileContent = editor.document.getText();
         // The validate function is currently not mapped to the appropriate logging functions
         const result = validate(filePath,fileProject,fileContent);
-        handleResult(result);
+        handleResult(result, editor);
         });
 
     context.subscriptions.push(disposable2);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -17,7 +17,7 @@ class OutputChannelTransport extends TransportStream {
             this.emit('logged', info);
         });
 
-        this.outputChannel.show();
+        this.outputChannel.show(true);
         this.outputChannel.appendLine(`[${info.label}] ${info.level}: ${info.message}`);
 
         if (callback) {

--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -5,8 +5,6 @@ import { request } from 'http';
 import { createMultipart /*, createResponseMessage */} from './mime';
 import { parseString } from 'xml2js';
 import { ServerResult } from '../client/server_result';
-import * as nisabaLogger from '../logger'
-import * as vscode from 'vscode';
 
 /*
 1. Gather all the information for the message from the text (start with hardcoded)
@@ -153,22 +151,4 @@ function commandSuccessful(responseID: string, url: string): boolean {
         }).end();
     }
     return done;
-}
-
-/**
- * Displays the results of a validation or lemmatisation operation in the GUI.
- *
- * @param result -- a ServerResult returned by e.g. `validate`
- */
-export function handleResult(result: ServerResult): void {
-    // Show a popup with the status of the result
-    if (result.contains_errors()) {
-        vscode.window.showErrorMessage(
-            'Validation identified errors. See log for details.');
-    } else {
-        vscode.window.showInformationMessage('Validation successful.');
-    }
-    // Show the log in the console and the log file
-    nisabaLogger.info(result.get_user_log());
-    // TODO Highlight the lines with errors
 }

--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -1,8 +1,12 @@
+// FIXME temporarily softening linting while server communication is commented out
+/* eslint no-unused-vars: "warn" */
 import * as AdmZip from 'adm-zip';
 import { request } from 'http';
 import { createMultipart /*, createResponseMessage */} from './mime';
 import { parseString } from 'xml2js';
 import { ServerResult } from '../client/server_result';
+import * as nisabaLogger from '../logger'
+import * as vscode from 'vscode';
 
 /*
 1. Gather all the information for the message from the text (start with hardcoded)
@@ -19,6 +23,9 @@ const oracc_log = `00atf/error_belsunu.atf:6:X001001: unknown block token: table
 ATF processor ox issued 2 warnings and 0 notices`;
 
 export function validate(filename: string, project: string, text: string): ServerResult {
+    // FIXME Temporarily commenting out server communication
+    // to test display of results.
+    /*
     let responseID:string;
     // First create the body of the message, since we'll need some information
     // from it to create the headers
@@ -99,6 +106,7 @@ export function validate(filename: string, project: string, text: string): Serve
     console.log('Sent message');
 
     console.log(fullMessage.toString());
+    */
 
     //TODO this is just a placeholder
     return new ServerResult(oracc_log);
@@ -144,4 +152,22 @@ function commandSuccessful(responseID: string, url: string): boolean {
         }).end();
     }
     return done;
+}
+
+/**
+ * Displays the results of a validation or lemmatisation operation in the GUI.
+ *
+ * @param result -- a ServerResult returned by e.g. `validate`
+ */
+export function handleResult(result: ServerResult): void {
+    // Show a popup with the status of the result
+    if (result.contains_errors()) {
+        vscode.window.showErrorMessage(
+            'Validation identified errors. See log for details.');
+    } else {
+        vscode.window.showInformationMessage('Validation successful.');
+    }
+    // Show the log in the console and the log file
+    nisabaLogger.info(result.get_user_log());
+    // TODO Highlight the lines with errors
 }

--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -20,7 +20,8 @@ import * as vscode from 'vscode';
 
 const oracc_log = `00atf/error_belsunu.atf:6:X001001: unknown block token: tableta
 00atf/error_belsunu.atf:44:X001001: o 4: translation uses undefined label
-ATF processor ox issued 2 warnings and 0 notices`;
+ATF processor ox issued 2 warnings and 0 notices
+`;
 
 export function validate(filename: string, project: string, text: string): ServerResult {
     // FIXME Temporarily commenting out server communication

--- a/src/test/suite/reference/user_log_error.log
+++ b/src/test/suite/reference/user_log_error.log
@@ -1,3 +1,5 @@
-/fake/path/error_belsunu.atf:6: unknown block token: tableta.
-/fake/path/error_belsunu.atf:44: o 4: translation uses undefined label.
+/fake/path/error_belsunu.atf:6:
+unknown block token: tableta.
+/fake/path/error_belsunu.atf:44:
+o 4: translation uses undefined label.
 ATF processor ox issued 2 warnings and 0 notices

--- a/src/test/suite/reference/user_log_error.log
+++ b/src/test/suite/reference/user_log_error.log
@@ -1,3 +1,3 @@
-Line 6: unknown block token: tableta.
-Line 44: o 4: translation uses undefined label.
+/fake/path/error_belsunu.atf:6: unknown block token: tableta.
+/fake/path/error_belsunu.atf:44: o 4: translation uses undefined label.
 ATF processor ox issued 2 warnings and 0 notices

--- a/src/test/suite/validation.test.ts
+++ b/src/test/suite/validation.test.ts
@@ -28,7 +28,7 @@ suite('Validation Test Suite', () => {
         const server_result = new ServerResult(oracc_log);
 
         // NB: The server response will always have \n as line separators!
-        assert.equal(server_result.user_log, expected_user_log);
+        assert.equal(server_result.get_user_log('/fake/path/error_belsunu.atf'), expected_user_log);
         // There's no sensible way to compare dictionaries, JSON.stringify
         // seemed the most straight forward
         assert.strictEqual(JSON.stringify(server_result.validation_errors),  JSON.stringify(expected_val_errors));
@@ -52,7 +52,7 @@ suite('Validation Test Suite', () => {
           'utf-8');
         const server_result = new ServerResult(oracc_log, ""); //We don't care about request.log for now
 
-        assert.equal(server_result.user_log, expected_user_log);
+        assert.equal(server_result.get_user_log('whatever'), expected_user_log);
         // There's no sensible way to compare dictionaries, JSON.stringify
         // seemed the most straight forward
         assert(JSON.stringify(server_result.validation_errors) == JSON.stringify(expected_val_errors));

--- a/src/test/suite/validation.test.ts
+++ b/src/test/suite/validation.test.ts
@@ -33,6 +33,7 @@ suite('Validation Test Suite', () => {
         // seemed the most straight forward
         assert.strictEqual(JSON.stringify(server_result.validation_errors),  JSON.stringify(expected_val_errors));
         assert.equal(server_result.summary_line, expected_summary_line);
+        assert(server_result.contains_errors());
     });
 
     test('Server results test for belsunu.atf', async() => {
@@ -56,6 +57,7 @@ suite('Validation Test Suite', () => {
         // seemed the most straight forward
         assert(JSON.stringify(server_result.validation_errors) == JSON.stringify(expected_val_errors));
         assert.equal(server_result.summary_line, expected_summary_line);
+        assert(!server_result.contains_errors());
     });
 
     test('SOAP client constructor test', async () => {

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,0 +1,50 @@
+import * as vscode from 'vscode';
+import * as nisabaLogger from './logger'
+import { ServerResult } from './client/server_result';
+
+
+// How we want to style the lines containing validation errors
+let lineErrorStyle: vscode.TextEditorDecorationType;
+
+/**
+ * Do any display-related setup we need for the extension.
+ */
+export function initView(): void {
+    lineErrorStyle = vscode.window.createTextEditorDecorationType({
+        textDecoration: "underline red wavy"
+    });
+}
+
+/**
+ * Displays the results of a validation or lemmatisation operation in the GUI.
+ *
+ * @param result -- a ServerResult returned by e.g. `validate`
+ */
+ export function handleResult(result: ServerResult): void {
+    // Show a popup with the status of the result
+    if (result.contains_errors()) {
+        vscode.window.showErrorMessage(
+            'Validation identified errors. See log for details.');
+    } else {
+        vscode.window.showInformationMessage('Validation successful.');
+    }
+    // Show the log in the console and the log file
+    nisabaLogger.info(result.get_user_log());
+    // Highlight the lines with errors, after clearing any existing highlights
+    const editor = vscode.window.activeTextEditor;
+    editor.setDecorations(lineErrorStyle, []);
+    if (result.contains_errors()) {
+        // We create an array of DecorationOptions, each of them specifying
+        // a single line (as a Range) and a message to be displayed on hover
+        const highlightOptions: vscode.DecorationOptions[] = [];
+        for (const [line, error] of Object.entries(result.validation_errors)) {
+            const line_num = Number(line) - 1;  // lines in API start from 0
+            highlightOptions.push({
+                range: editor.document.lineAt(line_num).range,
+                hoverMessage: new vscode.MarkdownString(error)
+            });
+        }
+        editor.setDecorations(lineErrorStyle, highlightOptions);
+    }
+
+}

--- a/src/view.ts
+++ b/src/view.ts
@@ -21,19 +21,12 @@ export function initView(): void {
  * @param result -- a ServerResult returned by e.g. `validate`
  * @param editor -- the TextEditor in which to display the errors
  */
- export function handleResult(result: ServerResult, editor: vscode.TextEditor): void {
-    // Show a popup with the status of the result
+export function handleResult(result: ServerResult, editor: vscode.TextEditor): void {
     if (result.contains_errors()) {
+        // Show a popup with the status of the result
         vscode.window.showErrorMessage(
             'Validation identified errors. See log for details.');
-    } else {
-        vscode.window.showInformationMessage('Validation successful.');
-    }
-    // Show the log in the console and the log file
-    nisabaLogger.info(result.get_user_log(editor.document.fileName));
-    // Highlight the lines with errors, after clearing any existing highlights
-    editor.setDecorations(lineErrorStyle, []);
-    if (result.contains_errors()) {
+        // Highlight the lines with errors
         // We create an array of DecorationOptions, each of them specifying
         // a single line (as a Range) and a message to be displayed on hover
         const highlightOptions: vscode.DecorationOptions[] = [];
@@ -54,7 +47,13 @@ export function initView(): void {
             })
         )
         */
+        // Any old highlights will be cleared before the new ones are applied
         editor.setDecorations(lineErrorStyle, highlightOptions);
+    } else {
+        // Show a success popup and clear all highlights
+        vscode.window.showInformationMessage('Validation successful.');
+        editor.setDecorations(lineErrorStyle, []);
     }
-
+    // Show the log in the console and the log file
+    nisabaLogger.info(result.get_user_log(editor.document.fileName));
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -30,7 +30,7 @@ export function initView(): void {
         vscode.window.showInformationMessage('Validation successful.');
     }
     // Show the log in the console and the log file
-    nisabaLogger.info(result.get_user_log());
+    nisabaLogger.info(result.get_user_log(editor.document.fileName));
     // Highlight the lines with errors, after clearing any existing highlights
     editor.setDecorations(lineErrorStyle, []);
     if (result.contains_errors()) {

--- a/src/view.ts
+++ b/src/view.ts
@@ -29,16 +29,6 @@ export function handleResult(result: ServerResult, editor: vscode.TextEditor): v
         // Highlight the lines with errors
         // We create an array of DecorationOptions, each of them specifying
         // a single line (as a Range) and a message to be displayed on hover
-        const highlightOptions: vscode.DecorationOptions[] = [];
-        for (const [line, error] of Object.entries(result.validation_errors)) {
-            const line_num = Number(line) - 1;  // lines in API start from 0
-            highlightOptions.push({
-                range: editor.document.lineAt(line_num).range,
-                hoverMessage: new vscode.MarkdownString(error)
-            });
-        }
-        // is this better?
-        /*
         const highlightOptions = Object.entries(result.validation_errors).map(
             ([line_number, error]) => ({
                 // line numbers in the editor API start from 0
@@ -46,7 +36,6 @@ export function handleResult(result: ServerResult, editor: vscode.TextEditor): v
                 hoverMessage: new vscode.MarkdownString(error)
             })
         )
-        */
         // Any old highlights will be cleared before the new ones are applied
         editor.setDecorations(lineErrorStyle, highlightOptions);
     } else {

--- a/src/view.ts
+++ b/src/view.ts
@@ -19,8 +19,9 @@ export function initView(): void {
  * Displays the results of a validation or lemmatisation operation in the GUI.
  *
  * @param result -- a ServerResult returned by e.g. `validate`
+ * @param editor -- the TextEditor in which to display the errors
  */
- export function handleResult(result: ServerResult): void {
+ export function handleResult(result: ServerResult, editor: vscode.TextEditor): void {
     // Show a popup with the status of the result
     if (result.contains_errors()) {
         vscode.window.showErrorMessage(
@@ -31,7 +32,6 @@ export function initView(): void {
     // Show the log in the console and the log file
     nisabaLogger.info(result.get_user_log());
     // Highlight the lines with errors, after clearing any existing highlights
-    const editor = vscode.window.activeTextEditor;
     editor.setDecorations(lineErrorStyle, []);
     if (result.contains_errors()) {
         // We create an array of DecorationOptions, each of them specifying

--- a/src/view.ts
+++ b/src/view.ts
@@ -44,6 +44,16 @@ export function initView(): void {
                 hoverMessage: new vscode.MarkdownString(error)
             });
         }
+        // is this better?
+        /*
+        const highlightOptions = Object.entries(result.validation_errors).map(
+            ([line_number, error]) => ({
+                // line numbers in the editor API start from 0
+                range: editor.document.lineAt(Number(line_number) - 1).range,
+                hoverMessage: new vscode.MarkdownString(error)
+            })
+        )
+        */
         editor.setDecorations(lineErrorStyle, highlightOptions);
     }
 


### PR DESCRIPTION
Addresses #29. Have commented out the communication with the server temporarily so we can use the mock result.

This
- shows a popup with the overall result of the validation
- logs the server response (to console and file)
- underlines the lines with errors