### PR TITLE
Add `original-fs` to the dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "nisaba",
             "version": "0.0.1",
             "dependencies": {
                 "adm-zip": "^0.5.5",
                 "mimemessage": "^1.0.5",
                 "node-fetch": "^2.6.1",
+                "original-fs": "^1.1.0",
                 "winston": "^3.3.3",
                 "winston-transport": "^4.4.0",
                 "xml2js": "^0.4.23"
@@ -3135,6 +3135,11 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/original-fs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/original-fs/-/original-fs-1.1.0.tgz",
+            "integrity": "sha512-LhW6DNoXdp8oo+Wv6N/QcxNrX/lE8McIySZ1O7llfJut4qA1Sfoy8BjHHWD6lHQMEdoFL+fosGK/DJSkQ5CP2g=="
         },
         "node_modules/os-tmpdir": {
             "version": "1.0.2",
@@ -7123,6 +7128,11 @@
                 "type-check": "~0.3.2",
                 "word-wrap": "~1.2.3"
             }
+        },
+        "original-fs": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/original-fs/-/original-fs-1.1.0.tgz",
+            "integrity": "sha512-LhW6DNoXdp8oo+Wv6N/QcxNrX/lE8McIySZ1O7llfJut4qA1Sfoy8BjHHWD6lHQMEdoFL+fosGK/DJSkQ5CP2g=="
         },
         "os-tmpdir": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
         "adm-zip": "^0.5.5",
         "mimemessage": "^1.0.5",
         "node-fetch": "^2.6.1",
+        "original-fs": "^1.1.0",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0",
         "xml2js": "^0.4.23"


### PR DESCRIPTION
When packaging the extension with webpack I get the following warning:

```
WARNING in ./node_modules/adm-zip/util/fileSystem.js 5:18-40
Module not found: Error: Can't resolve 'original-fs' in '/.../nisaba/node_modules/adm-zip/util'
 @ ./node_modules/adm-zip/util/index.js 2:0-51
 @ ./node_modules/adm-zip/adm-zip.js 1:14-31
 @ ./src/server/mime.ts 5:15-33
 @ ./src/server/messages.ts 14:15-32
 @ ./src/extension.ts 14:19-47
```