### PR TITLE
Let webpack ignore a warning about missing `original-fs` in `adm-zip`

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,32 +10,38 @@ const config = {
 
     entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
     output: {
-	// the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
-	path: path.resolve(__dirname, 'dist'),
-	filename: 'extension.js',
-	libraryTarget: 'commonjs2',
-	devtoolModuleFilenameTemplate: '../[resource-path]'
+        // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
+        path: path.resolve(__dirname, 'dist'),
+        filename: 'extension.js',
+        libraryTarget: 'commonjs2',
+        devtoolModuleFilenameTemplate: '../[resource-path]'
     },
     devtool: 'source-map',
     externals: {
-	vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
+        vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     },
     resolve: {
-	// support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-	extensions: ['.ts', '.js']
+        // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
+        extensions: ['.ts', '.js']
     },
+    ignoreWarnings: [
+        {
+            module: /adm-zip\/util\/fileSystem\.js/,
+            message: /Can't resolve 'original-fs'/,
+        },
+    ],
     module: {
-	rules: [
-	    {
-		test: /\.ts$/,
-		exclude: /node_modules/,
-		use: [
-		    {
-			loader: 'ts-loader'
-		    }
-		]
-	    }
-	]
+        rules: [
+            {
+                test: /\.ts$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader'
+                    }
+                ]
+            }
+        ]
     }
 };
 module.exports = config;


### PR DESCRIPTION
Note that `stats.warningsFilter` is deprecated in favor of `ignoreWarnings`.

Fix #65, close #63.