### PR TITLE
Remove Hello World command

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     ],
     "activationEvents": [
         "onCommand:ucl-rsdg.arabicPreview",
-        "onCommand:ucl-rsdg.helloWorld",
         "onCommand:ucl-rsdg.validateAtf"
     ],
     "main": "./dist/extension",
@@ -25,15 +24,6 @@
             {
                 "command": "ucl-rsdg.arabicPreview",
                 "title": "Show Arabic preview",
-                "category": "Oracc",
-                "icon": {
-                    "light": "media/preview_light.svg",
-                    "dark": "media/preview_dark.svg"
-                }
-            },
-            {
-                "command": "ucl-rsdg.helloWorld",
-                "title": "This is the title: Hello World",
                 "category": "Oracc",
                 "icon": {
                     "light": "media/preview_light.svg",
@@ -79,12 +69,6 @@
             ]
         },
         "keybindings": [
-            {
-                "command": "ucl-rsdg.helloWorld",
-                "key": "ctrl+I",
-                "mac": "cmd+I",
-                "when": "editorTextFocus && editorLangId == atf"
-            },
             {
                 "command": "ucl-rsdg.validateAtf",
                 "key": "ctrl+D",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,20 +20,6 @@ export function activate(context: vscode.ExtensionContext) {
     nisabaLogger.initLogging(nisabaOutputChannel);
     initView();
 
-    // The command has been defined in the package.json file
-    // Now provide the implementation of the command with registerCommand
-    // The commandId parameter must match the command field in package.json
-    const disposable1 = vscode.commands.registerCommand('ucl-rsdg.helloWorld', () => {
-        // The code you place here will be executed every time your command is executed
-
-        // Display a message box to the user
-        const str = 'Hello VS Code from ucl-rsdg!';
-        vscode.window.showWarningMessage(str);
-        nisabaLogger.warn(str);
-    });
-
-    context.subscriptions.push(disposable1);
-
     const disposable2 = vscode.commands.registerCommand('ucl-rsdg.validateAtf', async () => {
         const editor = vscode.window.activeTextEditor;
         const fileName = basename(editor.document.uri.fsPath);


### PR DESCRIPTION
This command has been here since the creation of the extension as a placeholder
for testing, but we don't really need it anymore.