### PR TITLE
Remove `docs/` and `media/` directories from package

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -11,3 +11,7 @@ src/**
 azure-pipelines.yml
 tsconfig.json
 webpack.config.js
+
+## Files to keep
+# This screenshot is used in the README
+!media/nisaba_ar_en_belsunu.png


### PR DESCRIPTION
This needs some discussion, and anyway should be merged after #76 and #78.  With these two pull requests we don't have any custom icons, and _**if**_ we aren't going to show the documentation locally, the directories `docs/` and `media/` are completely useless in the extension archive.  However we should discuss whether we want to show the documentation locally or not.  For the record, the size of the archive goes from 784 KiB to 420 KiB.

Opening as draft to discuss what to do first.