### PR TITLE
Show Nisaba buttons only when focus is on the text editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
                     "group": "navigation"
                 },
                 {
-                    "when": "resourceLangId == atf",
+                    "when": "editorTextFocus && resourceLangId == atf",
                     "command": "ucl-rsdg.aboutNisaba",
                     "group": "navigation"
                 }


### PR DESCRIPTION
This prevents users from clicking on these buttons when focus is on a different
area, e.g. the output channel, and getting very confusing results.

The only button I left is the "About" one, which should be safe to keep, but for consistency I could remove also this one.