### PR TITLE
Add more keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,11 +86,29 @@
         },
         "keybindings": [
             {
+                "command": "ucl-rsdg.aboutNisaba",
+                "key": "ctrl+H",
+                "mac": "cmd+H",
+                "when": "editorTextFocus && editorLangId == atf"
+            },
+	    {
                 "command": "ucl-rsdg.validateAtf",
                 "key": "ctrl+D",
                 "mac": "cmd+D",
                 "when": "editorTextFocus && editorLangId == atf"
-            }
+	    },
+            {
+                "command": "ucl-rsdg.lemmatiseAtf",
+                "key": "ctrl+L",
+                "mac": "cmd+L",
+                "when": "editorTextFocus && editorLangId == atf"
+            },
+	    {
+                "command": "ucl-rsdg.arabicPreview",
+                "key": "ctrl+;",
+                "mac": "cmd+;",
+                "when": "editorTextFocus && editorLangId == atf"
+	    }
         ],
         "languages": [
             {


### PR DESCRIPTION
Another pull request which may require some discussion! :grin: 

I have added default keybindings for all commands with buttons, based on [Nammu's ones](https://github.com/oracc/nammu/blob/9c7179545ea3355a2fe10c1166e079fbe6b9fd47/README.md#default-keystrokes).  One problem is that three out of these four keybindings conflict with [VS Code default keybindings](https://code.visualstudio.com/docs/getstarted/keybindings#_default-keyboard-shortcuts).  This may or may not be a problem depending on the user: experienced VS Code users may be used to use <kbd>Ctrl+D</kbd> or <kbd>Ctrl+L</kbd> for something else, novices will likely not care.  On the other hand, experienced user will probably know [how to deal with conflicts](https://code.visualstudio.com/docs/getstarted/keybindings#_detecting-keybinding-conflicts).

It looks _very_ hard to pick up simple keybindings that don't conflict with anything, only alternative would be to have complicated keybindings, which is...not great I guess.