### PR TITLE
Enable by default word wrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,24 +79,24 @@
                 "mac": "cmd+H",
                 "when": "editorTextFocus && editorLangId == atf"
             },
-	    {
+            {
                 "command": "ucl-rsdg.validateAtf",
                 "key": "ctrl+D",
                 "mac": "cmd+D",
                 "when": "editorTextFocus && editorLangId == atf"
-	    },
+            },
             {
                 "command": "ucl-rsdg.lemmatiseAtf",
                 "key": "ctrl+L",
                 "mac": "cmd+L",
                 "when": "editorTextFocus && editorLangId == atf"
             },
-	    {
+            {
                 "command": "ucl-rsdg.arabicPreview",
                 "key": "ctrl+;",
                 "mac": "cmd+;",
                 "when": "editorTextFocus && editorLangId == atf"
-	    }
+            }
         ],
         "languages": [
             {
@@ -117,7 +117,12 @@
                 "scopeName": "source.atf",
                 "path": "./syntaxes/atf.tmLanguage.json"
             }
-        ]
+        ],
+        "configurationDefaults": {
+            "[atf]": {
+                "editor.wordWrap": "on"
+            }
+        }
     },
     "scripts": {
         "clean": "rm -rf ./out",


### PR DESCRIPTION
ATF is a mostly plain text file format, it's reasonable to have word wrapping
enabled by default.  This is also what the Markdown extension does.

Fix #93.