### PR TITLE
Update node-fetch and use newer style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "dependencies": {
                 "adm-zip": "^0.5.5",
                 "mimemessage": "^1.0.5",
-                "node-fetch": "^2.6.7",
+                "node-fetch": "^3.1.1",
                 "winston": "^3.3.3",
                 "winston-transport": "^4.4.0",
                 "xml2js": "^0.4.23"
@@ -1125,6 +1125,14 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -1575,6 +1583,28 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
+        "node_modules/fetch-blob": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "paypal",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "dependencies": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            },
+            "engines": {
+                "node": "^12.20 || >= 14.13"
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1660,6 +1690,17 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "dependencies": {
+                "fetch-blob": "^3.1.2"
+            },
+            "engines": {
+                "node": ">=12.20.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -2474,23 +2515,39 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "node_modules/node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/jimmywarting"
+                },
+                {
+                    "type": "github",
+                    "url": "https://paypal.me/jimmywarting"
+                }
+            ],
+            "engines": {
+                "node": ">=10.5.0"
+            }
+        },
         "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+            "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
             "dependencies": {
-                "whatwg-url": "^5.0.0"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             },
             "engines": {
-                "node": "4.x || >=6.0.0"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
             },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/node-fetch"
             }
         },
         "node_modules/node-releases": {
@@ -3335,11 +3392,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
         "node_modules/traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -3509,10 +3561,13 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        "node_modules/web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
+            "engines": {
+                "node": ">= 8"
+            }
         },
         "node_modules/webpack": {
             "version": "5.67.0",
@@ -3633,15 +3688,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/which": {
@@ -4697,6 +4743,11 @@
                 "which": "^2.0.1"
             }
         },
+        "data-uri-to-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+        },
         "debug": {
             "version": "4.3.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -5044,6 +5095,15 @@
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
             "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
         },
+        "fetch-blob": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.4.tgz",
+            "integrity": "sha512-Eq5Xv5+VlSrYWEqKrusxY1C3Hm/hjeAsCGVG3ft7pZahlUAChpGZT/Ms1WmSLnEAisEXszjzu/s+ce6HZB2VHA==",
+            "requires": {
+                "node-domexception": "^1.0.0",
+                "web-streams-polyfill": "^3.0.3"
+            }
+        },
         "file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5108,6 +5168,14 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
+            }
+        },
+        "formdata-polyfill": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+            "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+            "requires": {
+                "fetch-blob": "^3.1.2"
             }
         },
         "fs.realpath": {
@@ -5722,12 +5790,19 @@
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
+        "node-domexception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+            "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+        },
         "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.2.0.tgz",
+            "integrity": "sha512-8xeimMwMItMw8hRrOl3C9/xzU49HV/yE6ORew/l+dxWimO5A4Ra8ld2rerlJvc/O7et5Z1zrWsPX43v1QBjCxw==",
             "requires": {
-                "whatwg-url": "^5.0.0"
+                "data-uri-to-buffer": "^4.0.0",
+                "fetch-blob": "^3.1.4",
+                "formdata-polyfill": "^4.0.10"
             }
         },
         "node-releases": {
@@ -6314,11 +6389,6 @@
                 "is-number": "^7.0.0"
             }
         },
-        "tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
         "traverse": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
@@ -6450,10 +6520,10 @@
                 "graceful-fs": "^4.1.2"
             }
         },
-        "webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+        "web-streams-polyfill": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
+            "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
         },
         "webpack": {
             "version": "5.67.0",
@@ -6530,15 +6600,6 @@
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
             "dev": true
-        },
-        "whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-            "requires": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
         },
         "which": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "package": "npx vsce package",
         "lint": "eslint src --ext ts",
         "pretest": "npm run compile && npm run lint",
-        "test": "node ./out/test/runTest.js"
+        "test": "node ./out/test/runTest.cjs"
     },
     "dependencies": {
         "adm-zip": "^0.5.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "type": "git",
         "url": "https://github.com/oracc/nisaba.git"
     },
+    "type": "module",
     "engines": {
         "vscode": "^1.44.0"
     },
@@ -20,7 +21,7 @@
         "onCommand:ucl-rsdg.lemmatiseAtf",
         "onCommand:ucl-rsdg.aboutNisaba"
     ],
-    "main": "./dist/extension",
+    "main": "./dist/extension.js",
     "contributes": {
         "commands": [
             {
@@ -134,7 +135,7 @@
     "dependencies": {
         "adm-zip": "^0.5.5",
         "mimemessage": "^1.0.5",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^3.1.1",
         "winston": "^3.3.3",
         "winston-transport": "^4.4.0",
         "xml2js": "^0.4.23"
@@ -143,7 +144,6 @@
         "@types/adm-zip": "^0.4.33",
         "@types/mocha": "^7.0.2",
         "@types/node": "^13.13.52",
-        "@types/node-fetch": "^2.5.12",
         "@types/vscode": "^1.44.0",
         "@types/xml2js": "^0.4.8",
         "@typescript-eslint/eslint-plugin": "^5.1.0",

--- a/src/client/SOAP_client.ts
+++ b/src/client/SOAP_client.ts
@@ -1,7 +1,7 @@
-import { default as fetch }from 'node-fetch';
-import { createEnvelopeMessage, extractLogs, getResponseCode, MultipartMessage, ServerAction } from './mime';
-import { ServerResult } from './server_result';
-import { log } from '../logger';
+import fetch from 'node-fetch';
+import { createEnvelopeMessage, extractLogs, getResponseCode, MultipartMessage, ServerAction } from './mime.js';
+import { ServerResult } from './server_result.js';
+import { log } from '../logger.js';
 
 /*
 1. Gather all the information for the message from the text (start with hardcoded)

--- a/src/client/mime.ts
+++ b/src/client/mime.ts
@@ -1,5 +1,5 @@
 import * as mimemessage from 'mimemessage';
-import * as AdmZip from 'adm-zip';
+import AdmZip from 'adm-zip';
 import { parseString } from 'xml2js';
 
 /**

--- a/src/client/mime.ts
+++ b/src/client/mime.ts
@@ -1,4 +1,4 @@
-import mimemessage = require('mimemessage');
+import * as mimemessage from 'mimemessage';
 import * as AdmZip from 'adm-zip';
 import { parseString } from 'xml2js';
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,14 @@
 import { basename } from 'path';
 
-import { lemmatise, ServerFunction, validate } from './server/messages';
+import { lemmatise, ServerFunction, validate } from './server/messages.js';
 
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
-import * as nisabaLogger from './logger';
-import { handleResult, initView } from './view';
-import { PreviewPanel } from './preview';
-import { getProjectCode } from './atf_model';
+import * as nisabaLogger from './logger.js';
+import { handleResult, initView } from './view.js';
+import { PreviewPanel } from './preview.js';
+import { getProjectCode } from './atf_model.js';
 
 // Logging output channel
 const nisabaOutputChannel = vscode.window.createOutputChannel("Nisaba");

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -2,7 +2,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as winston from 'winston';
-import * as TransportStream from 'winston-transport';
+import TransportStream from 'winston-transport';
 
 class OutputChannelTransport extends TransportStream {
     outputChannel: vscode.OutputChannel;

--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -1,5 +1,5 @@
-import { ServerResult } from '../client/server_result';
-import { SOAPClient } from '../client/SOAP_client';
+import { ServerResult } from '../client/server_result.js';
+import { SOAPClient } from '../client/SOAP_client.js';
 
 // The interface of functions which have to send information to the server
 // (for convenience in typing in other files)

--- a/src/test/runTest.cts
+++ b/src/test/runTest.cts
@@ -1,10 +1,8 @@
 import * as path from 'path';
-import { fileURLToPath } from 'url';
 
 import { runTests } from 'vscode-test';
 
 async function main() {
-    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     try {
         // The folder containing the Extension Manifest package.json
         // Passed to `--extensionDevelopmentPath`

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,8 +1,10 @@
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 import { runTests } from 'vscode-test';
 
 async function main() {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
     try {
         // The folder containing the Extension Manifest package.json
         // Passed to `--extensionDevelopmentPath`

--- a/src/test/suite/atf.test.ts
+++ b/src/test/suite/atf.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { getProjectCode } from '../../atf_model';
+import { getProjectCode } from '../../atf_model.js';
 
 suite('ATF Model Test Suite', () => {
     vscode.window.showInformationMessage('Start ATF tests.');

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import * as nisaba from '../../extension';
+import * as nisaba from '../../extension.js';
 
 suite('Extension Test Suite', () => {
     vscode.window.showInformationMessage('Start all tests.');

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as Mocha from 'mocha';
+import Mocha from 'mocha';
 import * as glob from 'glob';
 
 export function run(): Promise<void> {

--- a/src/test/suite/logger.test.ts
+++ b/src/test/suite/logger.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as tmp from 'tmp';
 import * as assert from 'assert';
-import * as nisabaLogger from '../../logger';
+import * as nisabaLogger from '../../logger.js';
 
 const nisabaOutputChannel = vscode.window.createOutputChannel("Nisaba");
 

--- a/src/test/suite/soap_messages.test.ts
+++ b/src/test/suite/soap_messages.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as AdmZip from 'adm-zip';
+import AdmZip from 'adm-zip';
 import { MultipartMessage, extractLogs } from '../../client/mime.js';
 
 suite('Messages test suite', () => {

--- a/src/test/suite/soap_messages.test.ts
+++ b/src/test/suite/soap_messages.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as AdmZip from 'adm-zip';
-import { MultipartMessage, extractLogs } from '../../client/mime';
+import { MultipartMessage, extractLogs } from '../../client/mime.js';
 
 suite('Messages test suite', () => {
 

--- a/src/test/suite/validation.test.ts
+++ b/src/test/suite/validation.test.ts
@@ -2,9 +2,9 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
-import { ServerResult } from '../../client/server_result';
-import { SOAPClient } from '../../client/SOAP_client';
-import { validate } from '../../server/messages';
+import { ServerResult } from '../../client/server_result.js';
+import { SOAPClient } from '../../client/SOAP_client.js';
+import { validate } from '../../server/messages.js';
 
 
 suite('Validation Test Suite', () => {

--- a/src/test/suite/validation.test.ts
+++ b/src/test/suite/validation.test.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import assert from 'assert';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';

--- a/src/view.ts
+++ b/src/view.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
-import * as nisabaLogger from './logger'
-import { ServerResult } from './client/server_result';
+import * as nisabaLogger from './logger.js'
+import { ServerResult } from './client/server_result.js';
 
 
 // How we want to style the lines containing validation errors

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "ES2020",
         "target": "es6",
         "outDir": "out",
         "lib": [
@@ -8,7 +8,8 @@
 	    "dom"
         ],
         "sourceMap": true,
-        "rootDir": "src"
+        "rootDir": "src",
+        "moduleResolution": "node"
     },
     "exclude": [
         "node_modules",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "ES2020",
+        "module": "node12",
         "target": "es6",
         "outDir": "out",
         "lib": [
@@ -9,7 +9,8 @@
         ],
         "sourceMap": true,
         "rootDir": "src",
-        "moduleResolution": "node"
+        "moduleResolution": "node12",
+        "esModuleInterop": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
Fixes #96.

- Moving to `fetch-node` v3.
- Removing type declarations as dependency (now bundled).
- Also requires updating the import style and some package settings to be (more?) compliant with ES6.

This may be useful long-term if more packages move to ES6-only imports.