### PR TITLE
Enforce `.atf` extension when submitting tasks to the server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,6 +71,16 @@ async function workWithServer(verb: string, callback: ServerFunction): Promise<v
     const fileName = basename(editor.document.uri.fsPath);
     const fileContent = editor.document.getText();
     let fileProject: string;
+    // The server would not show errors when validating/lemmatising the file if
+    // it doesn't have the `.atf` extension.  We could work around this
+    // limitation, but not setting the extension correctly is likely an error
+    // anyway, so we enforce it to when submitting tasks to the server.
+    if (!fileName.match(/\.atf$/)) {
+        vscode.window.showErrorMessage(`The file should have .atf extension,
+                                        but it is called "${fileName}".
+                                        Please rename it to add the extension.`);
+        return;
+    }
     try {
         fileProject = getProjectCode(fileContent);
     } catch (err) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ async function workWithServer(verb: string, callback: ServerFunction): Promise<v
     // it doesn't have the `.atf` extension.  We could work around this
     // limitation, but not setting the extension correctly is likely an error
     // anyway, so we enforce it to when submitting tasks to the server.
-    if (!fileName.match(/\.atf$/)) {
+    if (!fileName.endsWith(".atf")) {
         vscode.window.showErrorMessage(`The file should have .atf extension,
                                         but it is called "${fileName}".
                                         Please rename it to add the extension.`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,7 +78,7 @@ async function workWithServer(verb: string, callback: ServerFunction): Promise<v
     if (!fileName.endsWith(".atf")) {
         vscode.window.showErrorMessage(`The file should have .atf extension,
                                         but it is called "${fileName}".
-                                        Please rename it to add the extension.`);
+                                        Please rename it.`);
         return;
     }
     try {


### PR DESCRIPTION
Fix #99 by enforcing the `.atf` extension in the filename when submitting it to the server.  Happy to reword the error message if it isn't clear or it sounds odd.

Preview:

![image](https://user-images.githubusercontent.com/765740/152979963-8504e4e3-6ee2-45ce-843d-aac7ccb84772.png)
