### PR TITLE
Dispose disposable variables

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,28 +20,28 @@ export function activate(context: vscode.ExtensionContext) {
     nisabaLogger.initLogging(nisabaOutputChannel);
     initView();
 
-    const disposable2 = vscode.commands.registerCommand('ucl-rsdg.validateAtf', () => {
-        workWithServer("validate", validate);
-        });
+    context.subscriptions.push(
+        vscode.commands.registerCommand('ucl-rsdg.validateAtf', () => {
+            workWithServer("validate", validate);
+        })
+    );
 
-    context.subscriptions.push(disposable2);
-
-    const disposable3 = vscode.commands.registerCommand('ucl-rsdg.aboutNisaba', () => {
-        vscode.window.showInformationMessage(
-            'Nisaba is an editor for ATF files. Click below for more information and guidance.',
-            // Also show a button with "More information..."
-            "More information...")
-            .then( (chosenAction) => {
-                // if the user has clicked on the button, open a browser at our page
-                if (chosenAction != undefined) {
-                    vscode.env.openExternal(
-                        vscode.Uri.parse("https://github.com/oracc/nisaba/blob/master/docs/user_guide.md")
-                    )
-                }
-            })
-    });
-
-    context.subscriptions.push(disposable3);
+    context.subscriptions.push(
+        vscode.commands.registerCommand('ucl-rsdg.aboutNisaba', () => {
+            vscode.window.showInformationMessage(
+                'Nisaba is an editor for ATF files. Click below for more information and guidance.',
+                // Also show a button with "More information..."
+                "More information...")
+                .then( (chosenAction) => {
+                    // if the user has clicked on the button, open a browser at our page
+                    if (chosenAction != undefined) {
+                        vscode.env.openExternal(
+                            vscode.Uri.parse("https://github.com/oracc/nisaba/blob/master/docs/user_guide.md")
+                        )
+                    }
+                })
+        })
+    );
 
     context.subscriptions.push(
         vscode.commands.registerCommand('ucl-rsdg.lemmatiseAtf', () => {


### PR DESCRIPTION
I was going to add more commands here and stumbled again on these disposable
variables, which I never liked (but I'm also the person to blame for adding
them), and the odd names came up already in previous reviews:
https://github.com/oracc/nisaba/pull/72#discussion_r714308121.

This should be a non-functional change.
The diff is easier to read if excluding whitespace changes.