### PR TITLE
Add tests for lemmatisation

### DIFF
--- a/src/test/suite/input/arabic_no_lem.atf
+++ b/src/test/suite/input/arabic_no_lem.atf
@@ -1,0 +1,14 @@
+&X001001 = JCS 48, 089
+#project: cams/gkab
+#atf: lang akk-x-stdbab
+#atf: use unicode
+#atf: use math
+@tablet
+@obverse
+
+1.	[MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM
+
+@translation parallel ar project
+@obverse
+
+1. في شتة ٦٣ في شهر تبت، يوم ٢

--- a/src/test/suite/input/english_broken.atf
+++ b/src/test/suite/input/english_broken.atf
@@ -1,0 +1,21 @@
+&P393071 = SAAB 17, 1
+#project: ztcc
+#atf: lang akk-x-neoass
+#atf: use unicode
+@tablet
+
+@obverse
+1. 1(diš)# me 6(u)# ANŠE ŠE.PAD#-MEŠ
+
+
+#tr.en: 160 homers of barley
+
+2. TA IGI {m}b-ia#-a
+
+
+#tr.en: from the custody of Bayâ;
+
+3. 1(diš) ME 8(u) ANŠE {m}u₂-din#-ni
+
+
+#tr.en: 180 homers (from) Udīnu;

--- a/src/test/suite/input/english_no_lem.atf
+++ b/src/test/suite/input/english_no_lem.atf
@@ -1,0 +1,21 @@
+&P393071 = SAAB 17, 1
+#project: ztcc
+#atf: lang akk-x-neoass
+#atf: use unicode
+@tablet
+
+@obverse
+1. 1(diš)# me 6(u)# ANŠE ŠE.PAD#-MEŠ
+
+
+#tr.en: 160 homers of barley
+
+2. TA IGI {m}ba-ia#-a
+
+
+#tr.en: from the custody of Bayâ;
+
+3. 1(diš) ME 8(u) ANŠE {m}u₂-din#-ni
+
+
+#tr.en: 180 homers (from) Udīnu;

--- a/src/test/suite/lemmatisation.test.ts
+++ b/src/test/suite/lemmatisation.test.ts
@@ -19,7 +19,7 @@ suite('Lemmatisation Test Suite', () => {
                           `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString();
 
             assert(!server_result.contains_errors());
-            assert(server_result.atf_content === lemmatised_text);
+            assert.strictEqual(server_result.atf_content, lemmatised_text);
         });
     }
 
@@ -31,7 +31,7 @@ suite('Lemmatisation Test Suite', () => {
             const server_result = await lemmatise(`${file}_with_lem.atf`, project, text);
 
             assert(!server_result.contains_errors());
-            assert(text === server_result.atf_content);
+            assert.strictEqual(text, server_result.atf_content);
         });
     }
 

--- a/src/test/suite/lemmatisation.test.ts
+++ b/src/test/suite/lemmatisation.test.ts
@@ -16,7 +16,7 @@ suite('Lemmatisation Test Suite', () => {
             const server_result = await lemmatise(`${file}_no_lem.atf`, project, text);
             const lemmatised_text = fs.readFileSync(
                 path.join(__dirname,
-                          `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString();
+                          `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString().replace(/\r\n/g, '\n');
 
             assert(!server_result.contains_errors());
             assert.strictEqual(server_result.atf_content, lemmatised_text);
@@ -27,7 +27,7 @@ suite('Lemmatisation Test Suite', () => {
         test(`Lemmatisation results for ${file}_with_lem.atf`, async () => {
             const text = fs.readFileSync(
                 path.join(__dirname,
-                          `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString();
+                          `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString().replace(/\r\n/g, '\n');
             const server_result = await lemmatise(`${file}_with_lem.atf`, project, text);
 
             assert(!server_result.contains_errors());

--- a/src/test/suite/lemmatisation.test.ts
+++ b/src/test/suite/lemmatisation.test.ts
@@ -1,0 +1,46 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { lemmatise } from '../../server/messages';
+
+
+suite('Lemmatisation Test Suite', () => {
+    vscode.window.showInformationMessage('Start lemmatisation tests.');
+
+    for (const [file, project] of [['english', 'ztcc'], ['arabic', 'cams/gkab']]) {
+        test(`Lemmatisation results for ${file}_no_lem.atf`, async () => {
+            const text = fs.readFileSync(
+                path.join(__dirname,
+                          `../../../src/test/suite/input/${file}_no_lem.atf`)).toString();
+            const server_result = await lemmatise(`${file}_no_lem.atf`, project, text);
+            const lemmatised_text = fs.readFileSync(
+                path.join(__dirname,
+                          `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString();
+
+            assert(!server_result.contains_errors());
+            assert(server_result.atf_content === lemmatised_text);
+        });
+    }
+
+    for (const [file, project] of [['english', 'ztcc'], ['arabic', 'cams/gkab']]) {
+        test(`Lemmatisation results for ${file}_with_lem.atf`, async () => {
+            const text = fs.readFileSync(
+                path.join(__dirname,
+                          `../../../src/test/suite/reference/${file}_with_lem.atf`)).toString();
+            const server_result = await lemmatise(`${file}_with_lem.atf`, project, text);
+
+            assert(!server_result.contains_errors());
+            assert(text === server_result.atf_content);
+        });
+    }
+
+    test('Lemmatisation results when there are errors', async () => {
+        const text = fs.readFileSync(
+            path.join(__dirname,
+                      '../../../src/test/suite/input/english_broken.atf')).toString();
+        const server_result = await lemmatise('english_broken.atf', 'ztcc', text);
+
+        assert(server_result.contains_errors());
+    });
+});

--- a/src/test/suite/reference/arabic_with_lem.atf
+++ b/src/test/suite/reference/arabic_with_lem.atf
@@ -1,0 +1,15 @@
+&X001001 = JCS 48, 089
+#project: cams/gkab
+#atf: lang akk-x-stdbab
+#atf: use unicode
+#atf: use math
+@tablet
+@obverse
+
+1.	[MU] 1.03-KAM {iti}AB GE₆ U₄ 2-KAM
+#lem: šanat[year]N; n; Ṭebetu[1]MN; mūša[at night]AV; ūm[day]N; n
+
+@translation parallel ar project
+@obverse
+
+1. في شتة ٦٣ في شهر تبت، يوم ٢

--- a/src/test/suite/reference/english_with_lem.atf
+++ b/src/test/suite/reference/english_with_lem.atf
@@ -1,0 +1,24 @@
+&P393071 = SAAB 17, 1
+#project: ztcc
+#atf: lang akk-x-neoass
+#atf: use unicode
+@tablet
+
+@obverse
+1. 1(diš)# me 6(u)# ANŠE ŠE.PAD#-MEŠ
+#lem: n; mē[(one) hundred]NU; n; imāru[donkey]N; X
+
+
+#tr.en: 160 homers of barley
+
+2. TA IGI {m}ba-ia#-a
+#lem: issu[from]PRP; pān[front]N; X
+
+
+#tr.en: from the custody of Bayâ;
+
+3. 1(diš) ME 8(u) ANŠE {m}u₂-din#-ni
+#lem: n; X; n; imāru[donkey]N; X
+
+
+#tr.en: 180 homers (from) Udīnu;


### PR DESCRIPTION
I basically replicated [the tests in Nammu](https://github.com/oracc/nammu/blob/9c7179545ea3355a2fe10c1166e079fbe6b9fd47/python/nammu/test/test_nammu.py#L164-L193).  Could maybe add more?

When this is ready, it should close #4.