### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to the "atf" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [1.3.0] - 2022-??-??
+## [1.3.0] - 2022-10-11
 
 ### Added
 
 - Glossary files (`*.glo`) have now a searchable and clickable outline of letters and entries.
-- Validation and lemmatisation support files with multiple texts, as long as they share the same project code.
+- Validation and lemmatisation of ATF files support files with multiple texts, as long as they share the same project code.
 
 ## [1.2.0] - 2022-06-28
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nisaba",
     "displayName": "Nisaba",
     "description": "Support for ATF files, like those used by Oracc and the Nahrein Network.",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "publisher": "UCLResearchSoftwareDevelopmentGroup",
     "repository": {
         "type": "git",


### PR DESCRIPTION
v1.3 or v1.4?  We can do v1.3 now, and v1.4 after #108 is completed, to have the full glossary support in v1.2 -> v1.4 transition.

_**NOTE**_: need to update release date and maybe version number in ChangeLog file before merging.