### PR TITLE
Update for deprecated GitHub Actions syntax

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,7 +20,7 @@ jobs:
         TAG="v$(jq -M .version package.json | tr -d '"'| tr -d \')"
         echo "Tag: ${TAG}"
         echo "Prerelease: ${{ inputs.prerelease }}"
-        echo "::set-output name=TAG::${TAG}"
+        echo "TAG=${TAG}" >> $GITHUB_OUTPUT
     - name: Create release
       uses: softprops/action-gh-release@v1
       with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.