### PR TITLE
Log more debug messages during interaction with server

### DIFF
--- a/src/atf_model.ts
+++ b/src/atf_model.ts
@@ -1,3 +1,5 @@
+import * as nisabaLogger from './logger'
+
 /**
  * Extract the project code from an ATF file.
  *
@@ -14,6 +16,7 @@ export function getProjectCode(atfText: string): string {
                     .filter(line => line.startsWith(tag))
                     .map(line => line.slice(tag.length).trim());
     if ((new Set(codes)).size == 1) {
+        nisabaLogger.debug(`Project code found: "${codes[0]}"`);
         return codes[0];
     }
     if (codes.length == 0) {

--- a/src/client/SOAP_client.ts
+++ b/src/client/SOAP_client.ts
@@ -49,7 +49,11 @@ export class SOAPClient {
     async sendInitialRequest(command): Promise<string> {
         const fullMessage = new MultipartMessage(command, this.atf_filename,
                                                  this.atf_project, this.atf_text);
-        log('debug', fullMessage.toString());
+        // `fullMessage.attachment` is only binary data, not useful to log, and
+        // `fullMessage._message` contains all previous fields (including attachment),
+        // avoid logging duplicates.
+        log('debug', `Full message boundary: ${fullMessage.boundary}`);
+        log('debug', `Full message envelope: ${fullMessage.envelope}`);
         const body = fullMessage.getBody();
 
         const headers = fullMessage.getHeaders();
@@ -121,8 +125,8 @@ export class SOAPClient {
         const responseContents = await response.buffer();
         const allLogs = extractLogs(responseContents);
         allLogs.forEach( (contents, name) => {
-                log('debug', `${name}`)
-                log('debug', `${contents}`)
+                log('debug', `Log file name: ${name}`)
+                log('debug', `Log contents: ${contents}`)
             });
         return allLogs;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ export function activate(context: vscode.ExtensionContext) {
  */
 async function workWithServer(verb: string, callback: ServerFunction): Promise<void> {
     const editor = vscode.window.activeTextEditor;
-    const fileName = basename(editor.document.uri.fsPath);
+    const fileName = basename(editor.document.fileName);
     const fileContent = editor.document.getText();
     let fileProject: string;
     // The server would not show errors when validating/lemmatising the file if
@@ -89,6 +89,7 @@ async function workWithServer(verb: string, callback: ServerFunction): Promise<v
         return;
     }
     try {
+        nisabaLogger.debug(`Extracting project code for ${fileName}`);
         fileProject = getProjectCode(fileContent);
     } catch (err) {
         vscode.window.showErrorMessage(`Could not ${verb}: ${err}`);


### PR DESCRIPTION
While debugging #129 (which I still can't reproduce locally, the provided file works for me on Linux :cry:) I noticed that interactions with the server could do it with a bit more of debug messages (like the name of the project found), or a bit clearer (prefix `names` and `contents` with what they are) or actually printing something useful (`fullMessage.toString()` is just `[object Object]`).