### PR TITLE
In log message refer to ATF lemmatisation with the correct name

### DIFF
--- a/src/client/server_result.ts
+++ b/src/client/server_result.ts
@@ -64,7 +64,8 @@ export class ServerResult {
      */
     get_user_log(filepath: string){
         if (!this.contains_errors()){
-            return "ATF validation returned no errors.";
+            const process = this.contains_lemmata() ? "lemmatisation" : "validation";
+            return `ATF ${process} returned no errors.`;
         }
         else {
             let user_log = Object.entries(this.validation_errors)


### PR DESCRIPTION
At the end of the lemmatisation process we were printing "ATF validation returned no errors", which was a bit confusing.