### PR TITLE
Restore "About Nisaba" button

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
                     "group": "navigation@3"
                 },
                 {
-                    "when": "editorTextFocus && (resourceLangId == atf || resourceLangId == glo)",
+                    "when": "editorTextFocus && resourceLangId == atf || resourceLangId == glo",
                     "command": "ucl-rsdg.aboutNisaba",
                     "group": "navigation@1"
                 }


### PR DESCRIPTION
It was accidentally removed because apparently the `when` clause does not
support parentheses.