### PR TITLE
Release v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "atf" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [1.4.0] - 2022-12-16
+## [1.4.1] - 2022-12-16
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nisaba",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "nisaba",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "dependencies": {
                 "adm-zip": "^0.5.5",
                 "mimemessage": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nisaba",
     "displayName": "Nisaba",
     "description": "Support for ATF files, like those used by Oracc and the Nahrein Network.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "publisher": "UCLResearchSoftwareDevelopmentGroup",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Release v1.4.0 was rejected because of a problem in the README file, but we
can't replace it because it exists anyway in Azure, so we have to do a brand-new
release even if v1.4.0 doesn't appear anywhere visible to users.