### PR TITLE
[CI] Ungroup NPM Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,8 +17,3 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 99
-  groups:
-    # Group all NPM PRs into a single PR:
-    all-npm-actions:
-      patterns:
-        - "*"


### PR DESCRIPTION
It turned out this wasn't a great idea in practice here.