### PR TITLE
Change `response.buffer` -> `response.arrayBuffer`

### DIFF
--- a/src/client/SOAP_client.ts
+++ b/src/client/SOAP_client.ts
@@ -122,7 +122,7 @@ export class SOAPClient {
             `${this.url}:${this.port}`,
             {method: 'POST', body: message}
         );
-        const responseContents = await response.buffer();
+        const responseContents = await response.arrayBuffer();
         const allLogs = extractLogs(responseContents);
         allLogs.forEach( (contents, name) => {
                 log('debug', `Log file name: ${name}`)

--- a/src/client/SOAP_client.ts
+++ b/src/client/SOAP_client.ts
@@ -122,7 +122,8 @@ export class SOAPClient {
             `${this.url}:${this.port}`,
             {method: 'POST', body: message}
         );
-        const responseContents = await response.arrayBuffer();
+        const responseContentsArray = await response.arrayBuffer();
+        const responseContents = Buffer.from(responseContentsArray);
         const allLogs = extractLogs(responseContents);
         allLogs.forEach( (contents, name) => {
                 log('debug', `Log file name: ${name}`)


### PR DESCRIPTION
This resolves a deprecation warning in new `node-fetch`.

***Edit***: aargh, this needs more work.